### PR TITLE
removeFront method potential bug fixes

### DIFF
--- a/module_1/lists/ArrayBasedList.java
+++ b/module_1/lists/ArrayBasedList.java
@@ -66,7 +66,7 @@ public class ArrayBasedList<E> implements ListADT<E> {
             E firstElement = (E) elements[0]; // read the element before removing it
 
             // shift all the elements one position to the left
-            for (int i = 0; i < size; i++) {
+            for (int i = 0; i < size - 1; i++) {
                 elements[i] = elements[i + 1];
             }
             size = size - 1; // note that we could also set the last element to null for memory optimization

--- a/module_1/lists/ArrayBasedList.java
+++ b/module_1/lists/ArrayBasedList.java
@@ -69,6 +69,8 @@ public class ArrayBasedList<E> implements ListADT<E> {
             for (int i = 0; i < size - 1; i++) {
                 elements[i] = elements[i + 1];
             }
+
+            elements[size - 1] = null; // ensures the last element is set to null.
             size = size - 1; // note that we could also set the last element to null for memory optimization
 
             return firstElement;


### PR DESCRIPTION
Correction of the for-loop to iterate until size-1 to avoid accessing an element outside the array bounds when shifting elements to the left in the removeFront method. Also, set the last element to null after shifting to prevent a potential memory leak.